### PR TITLE
While and Until

### DIFF
--- a/lib/until.rb
+++ b/lib/until.rb
@@ -1,6 +1,9 @@
 def using_until
     levitation_force = 6
-    #your code here
+    until levitation_force == 10
+      puts "Wingardium Leviosa"
+      levitation_force += 1
+    end
     
 end
 

--- a/lib/while.rb
+++ b/lib/while.rb
@@ -1,7 +1,9 @@
 def using_while
 	levitation_force = 6
-	
-	#your code here
+	while levitation_force < 10
+    puts "Wingardium Leviosa"
+    levitation_force += 1
+  end
 end
 
 


### PR DESCRIPTION
Reviews the ```while``` and ```until``` constructs and how they offer different arguably more dynamic ways to loop in ruby.

First ```while``` allows us to loop WHILE something is still the case. 

Second ```until``` loops UNTIL something is the case, a good way to remember "until" as pointed out by Learn.co is that is means "if not" the same way I learned how to use it during LSAT training. 